### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -5,6 +5,7 @@ Authentication endpoints for the High School Management System API
 from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
 import hashlib
+from argon2 import PasswordHasher
 
 from ..database import teachers_collection
 
@@ -13,20 +14,28 @@ router = APIRouter(
     tags=["auth"]
 )
 
+from argon2 import PasswordHasher
+
+ph = PasswordHasher()
+
 def hash_password(password):
-    """Hash password using SHA-256"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash password using Argon2"""
+    return ph.hash(password)
 
 @router.post("/login")
 def login(username: str, password: str) -> Dict[str, Any]:
     """Login a teacher account"""
     # Hash the provided password
-    hashed_password = hash_password(password)
-    
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or teacher["password"] != hashed_password:
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    
+    try:
+        # Verify the provided password
+        ph.verify(teacher["password"], password)
+    except Exception:
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)


### PR DESCRIPTION
Potential fix for [https://github.com/Ubayed-Bin-Sufian/skills-introduction-to-repository-management/security/code-scanning/1](https://github.com/Ubayed-Bin-Sufian/skills-introduction-to-repository-management/security/code-scanning/1)

To fix the issue, we need to replace the insecure SHA-256 hashing mechanism with a secure password hashing algorithm, such as Argon2. Argon2 is computationally expensive, includes a salt by default, and is designed specifically for password hashing. The `argon2-cffi` library can be used to implement this.

Steps to fix:
1. Replace the `hash_password` function to use Argon2 for hashing passwords.
2. Update the `login` function to verify the password using Argon2's `verify` method.
3. Add the necessary import for `argon2-cffi`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
